### PR TITLE
Fix sign in client-side exception error

### DIFF
--- a/src/lib/auth-client.ts
+++ b/src/lib/auth-client.ts
@@ -1,9 +1,8 @@
 import { createAuthClient } from "better-auth/react";
 import { emailOTPClient, adminClient } from "better-auth/client/plugins";
-import { appConfig } from '@/config/app';
 
 export const authClient = createAuthClient({
-  baseURL: appConfig.baseUrl,
+  baseURL: process.env.NEXT_PUBLIC_APP_URL || (typeof window !== 'undefined' ? window.location.origin : 'http://localhost:3000'),
   plugins: [
     emailOTPClient(),
     adminClient(),


### PR DESCRIPTION
The auth-client was importing appConfig which tried to access server-only environment variables (BETTER_AUTH_URL, NEXTAUTH_URL) on the client side, causing a client-side exception. Fixed by directly using NEXT_PUBLIC_APP_URL in the auth client configuration instead of importing the entire app config.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration handling to improve deployment flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->