### PR TITLE
fix: remove auto-resend OTP that was causing client-side error

### DIFF
--- a/src/components/Auth/SigninWithPassword.tsx
+++ b/src/components/Auth/SigninWithPassword.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import React, { useState } from "react";
 import InputGroup from "../FormElements/InputGroup";
 import { Checkbox } from "../FormElements/checkbox";
-import { signIn, authClient } from "@/lib/auth-client";
+import { signIn } from "@/lib/auth-client";
 import { useRouter } from "next/navigation";
 import { toast } from "react-hot-toast";
 
@@ -44,18 +44,7 @@ export default function SigninWithPassword() {
       // Check if email is verified
       const user = result.data?.user;
       if (user && !user.emailVerified && (user as any).role !== 'SUPER_ADMIN') {
-        // Resend OTP in case the original one expired
-        try {
-          await authClient.emailOtp.sendVerificationOtp({
-            email: user.email || data.email,
-            type: 'email-verification'
-          });
-          toast.success('A new verification code has been sent to your email.');
-        } catch (error) {
-          console.error('Failed to resend verification code:', error);
-          // Continue anyway - user might still have the original code
-        }
-
+        toast.error('Please verify your email address before logging in. Check your inbox for the verification code.');
         setLoading(false);
         // Redirect to email verification page
         router.push(`/auth/email-verified?unverified=true&email=${encodeURIComponent(user.email || data.email)}`);


### PR DESCRIPTION
Simplified the unverified email login flow by removing the automatic OTP resend which was causing application errors. Users can use the resend button on the verification page if needed.

The main fix (middleware redirect with email parameter) remains intact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated sign-in flow to properly handle unverified email accounts, displaying an error message and directing users to email verification instead of attempting OTP resend.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->